### PR TITLE
Fix some compiler warnings

### DIFF
--- a/image/sys/strcodec.c
+++ b/image/sys/strcodec.c
@@ -668,9 +668,7 @@ ERR detach_SB(SimpleBitIO* pSB)
 // WinCE ARM and Desktop x86
 #else
 // other platform
-#ifdef _BIG__ENDIAN_
-#define _byteswap_ulong(x)  (x)
-#else // _BIG__ENDIAN_
+#ifndef _BIG__ENDIAN_
 U32 _byteswap_ulong(U32 bits)
 {
     U32 r = (bits & 0xffu) << 24;

--- a/image/sys/strcodec.h
+++ b/image/sys/strcodec.h
@@ -64,7 +64,7 @@
 
 #ifndef UNREFERENCED_PARAMETER
 #define UNREFERENCED_PARAMETER(P) { (P) = (P); }
-#endif UNREFERENCED_PARAMETER
+#endif // UNREFERENCED_PARAMETER
 
 #ifdef UNDER_CE
 #define PLATFORM_WCE
@@ -673,6 +673,16 @@ void flushToByte(BitIOInfo* pIO);
     pIO->cBitsUsed &= 16 - 1;\
     pIO->uiAccumulator = LOAD16(pIO->pbCurrent) << pIO->cBitsUsed;\
     return 0;
-//    pIO->uiAccumulator = LOAD16(pIO->pbCurrent) & ((U32)(-1) >> pIO->cBitsUsed);\
 
 void OutputPerfTimerReport(CWMImageStrCodec *pState);
+
+#if (defined(WIN32) && !defined(UNDER_CE)) || (defined(UNDER_CE) && defined(_ARM_))
+// WinCE ARM and Desktop x86
+#else
+// other platform
+#ifdef _BIG__ENDIAN_
+#define _byteswap_ulong(x)  (x)
+#else // _BIG__ENDIAN_
+U32 _byteswap_ulong(U32 bits);
+#endif // _BIG__ENDIAN_
+#endif

--- a/image/sys/windowsmediaphoto.h
+++ b/image/sys/windowsmediaphoto.h
@@ -258,19 +258,17 @@ typedef long ERR;
 #endif
 
 #define Call(exp) \
-    if (Failed(err = (exp))) \
+    do if (Failed(err = (exp))) \
     { \
         Report(err, #exp, __FILE__, (long)__LINE__); \
         goto Cleanup; \
-    } \
-    else err = err
+    } while(0)
 
 #define CallIgnoreError(errTmp, exp) \
-    if (Failed(errTmp = (exp))) \
+    do if (Failed(errTmp = (exp))) \
     { \
         Report(errTmp, #exp, __FILE__, (long)__LINE__); \
-    } \
-    else errTmp = errTmp
+    } while (0)
 
 
 #define Test(exp, err) Call((exp) ? WMP_errSuccess : (err))

--- a/jxrencoderdecoder/JxrDecApp.c
+++ b/jxrencoderdecoder/JxrDecApp.c
@@ -427,7 +427,7 @@ ERR WmpDecAppCreateEncoderFromExt(
     Call(GetTestEncodeIID(szExt, &pIID));
 
     // Create encoder
-    Call(PKTestFactory_CreateCodec(pIID, ppIE));
+    Call(PKTestFactory_CreateCodec(pIID, (void **)ppIE));
 
 Cleanup:
     return err;

--- a/jxrgluelib/JXRGlueJxr.c
+++ b/jxrgluelib/JXRGlueJxr.c
@@ -28,6 +28,7 @@
 //*@@@---@@@@******************************************************************
 #include <limits.h>
 #include <JXRGlue.h>
+#include <wchar.h>
 
 
 static const char szHDPhotoFormat[] = "<dc:format>image/vnd.ms-photo</dc:format>";

--- a/jxrgluelib/JXRGluePFC.c
+++ b/jxrgluelib/JXRGluePFC.c
@@ -56,9 +56,9 @@ static U32 Convert_Half_To_Float(U16 u16)
     {
         return s << 31;
     }
-    else if (~(~0 << 5) == e) // inf, snan, qnan
+    else if (~(~0U << 5) == e) // inf, snan, qnan
     {
-        return (s << 31) | ~(~0 << 8) << 23| (m << 13);
+        return (s << 31) | ~(~0U << 8) << 23| (m << 13);
     }
 
     return (s << 31) | ((e - 15 + 127) << 23) | (m << 13); // norm

--- a/jxrtestlib/JXRTest.c
+++ b/jxrtestlib/JXRTest.c
@@ -198,7 +198,7 @@ ERR PKTestFactory_CreateDecoderFromFile(const char* szFilename, PKImageDecode** 
     ERR err = WMP_errSuccess;
 
     char *pExt = NULL;
-    PKIID* pIID = NULL;
+    const PKIID* pIID = NULL;
 
     struct WMPStream* pStream = NULL;
     PKImageDecode* pDecoder = NULL;
@@ -214,7 +214,7 @@ ERR PKTestFactory_CreateDecoderFromFile(const char* szFilename, PKImageDecode** 
     Call(CreateWS_File(&pStream, szFilename, "rb"));
 
     // Create decoder
-    Call(PKTestFactory_CreateCodec(pIID, ppDecoder));
+    Call(PKTestFactory_CreateCodec(pIID, (void**)ppDecoder));
     pDecoder = *ppDecoder;
 
     // attach stream to decoder
@@ -232,7 +232,7 @@ ERR PKCreateTestFactory(PKCodecFactory** ppCFactory, U32 uVersion)
 
     UNREFERENCED_PARAMETER( uVersion );
 
-    Call(PKAlloc(ppCFactory, sizeof(**ppCFactory)));
+    Call(PKAlloc((void**)ppCFactory, sizeof(**ppCFactory)));
     pCFactory = *ppCFactory;
 
     pCFactory->CreateCodec = PKTestFactory_CreateCodec;
@@ -287,7 +287,7 @@ ERR PKTestDecode_Release(
 
     pID->fStreamOwner && pID->pStream->Close(&pID->pStream);
 
-    return PKFree(ppID);
+    return PKFree((void**)ppID);
 }
 
 ERR PKTestDecode_Create(
@@ -296,7 +296,7 @@ ERR PKTestDecode_Create(
     ERR err = WMP_errSuccess;
     PKTestDecode* pID = NULL;
 
-    Call(PKAlloc(ppID, sizeof(**ppID)));
+    Call(PKAlloc((void**)ppID, sizeof(**ppID)));
 
     pID = *ppID;
     pID->Initialize = PKTestDecode_Initialize;

--- a/jxrtestlib/JXRTestHdr.c
+++ b/jxrtestlib/JXRTestHdr.c
@@ -27,7 +27,7 @@
 //*@@@---@@@@******************************************************************
 #ifndef ANSI
 #define _CRT_SECURE_NO_WARNINGS
-#endif ANSI
+#endif // ANSI
 
 #include <stdlib.h>
 #include <string.h>

--- a/jxrtestlib/JXRTestPnm.c
+++ b/jxrtestlib/JXRTestPnm.c
@@ -27,7 +27,7 @@
 //*@@@---@@@@******************************************************************
 #ifndef ANSI
 #define _CRT_SECURE_NO_WARNINGS
-#endif ANSI
+#endif // ANSI
 
 #include <stdlib.h>
 

--- a/jxrtestlib/JXRTestTif.c
+++ b/jxrtestlib/JXRTestTif.c
@@ -909,8 +909,8 @@ ERR PKImageDecode_Release_TIF(PKTestDecode** ppID)
 
     PKTestDecode *pID = *ppID;
 
-    Call(WMPFree(&pID->EXT.TIF.uStripOffsets));
-    Call(WMPFree(&pID->EXT.TIF.uStripByteCounts));
+    Call(WMPFree((void**)&pID->EXT.TIF.uStripOffsets));
+    Call(WMPFree((void**)&pID->EXT.TIF.uStripByteCounts));
 
     Call(PKTestDecode_Release(ppID));
 


### PR DESCRIPTION
This addresses various compiler warnings raised by clang on FreeBSD, some more trivial than others.