### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,5 +1,8 @@
 name: C/C++ CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/mircomir/jxrlib/security/code-scanning/11](https://github.com/mircomir/jxrlib/security/code-scanning/11)

Add an explicit `permissions` block to the workflow file `.github/workflows/c-cpp.yml` at the top level (recommended here since there is only one job). Set least privilege required for current behavior:

- `contents: read`

This preserves existing functionality (`actions/checkout` and `make`) while constraining `GITHUB_TOKEN` permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
